### PR TITLE
LUR Caching Policy 구현

### DIFF
--- a/Sources/Feather/Cache/FTDiskCache.swift
+++ b/Sources/Feather/Cache/FTDiskCache.swift
@@ -12,7 +12,7 @@ public final class FTDiskCache: @unchecked Sendable {
   public static let shared = FTDiskCache()
   public var config: FTDiskCacheConfig? = nil {
     didSet {
-      guard let config else { self.ttl = 60 * 60 * 24; return }
+      guard let config else { self.ttl = FTConstant.defaultTimeOut; return }
       self.ttl = config.timeOut
     }
   }
@@ -28,30 +28,32 @@ public final class FTDiskCache: @unchecked Sendable {
     self.ttl = ttl
   }
   
-  func save(requestURL: URL, data: Data, eTag: String?, modified: String?) {
+  func save(requestURL: URL, data: Data, eTag: String?, modified: String?) async {
     let fileName = sha256(requestURL.absoluteString)
-    guard !fileManager.fileExists(fileName: fileName) else { return }
-    config?.policy?.execute(deleteHandler: {
-      delete(fileName: $0)
-    })
-    fileManager.create(fileName: fileName, data: data, eTag: eTag, modified: modified)
+    guard await !fileManager.fileExists(fileName: fileName) else { return }
+    await fileManager.create(fileName: fileName, data: data, eTag: eTag, modified: modified)
+    if let deleteFiles = await config?.policy?.execute() {
+      for deleteFile in deleteFiles {
+        await delete(fileName: deleteFile.lastPathComponent)
+      }
+    }
   }
   
-  func read(requestURL: URL) -> (FTCacheInfo, Bool)? {
+  func read(requestURL: URL) async -> (FTCacheInfo, Bool)? {
     let fileName = sha256(requestURL.absoluteString)
-    let readFileURL = fileManager.path(fileName: fileName)
-    guard fileManager.fileExists(fileName: fileName),
+    let readFileURL = await fileManager.path(fileName: fileName)
+    guard await fileManager.fileExists(fileName: fileName),
           let imageData = try? Data(contentsOf: readFileURL.appending(path: "image")) else { return nil }
-    if isTimeOut(fileName: fileName) {
+    if await isTimeOut(fileName: fileName) {
       let cache = FTCacheInfo(
         imageData: imageData,
         eTag: try? String(contentsOf: readFileURL.appending(path: "eTag.txt"), encoding: .utf8),
         modified: try? String(contentsOf: readFileURL.appending(path: "modified.txt"), encoding: .utf8)
       )
-      delete(fileName: fileName)
+      await delete(fileName: fileName)
       return (cache, false)
     }
-    config?.policy?.updateAccessTime(fileName: fileName)
+    await config?.policy?.updateAccessTime(fileName: fileName)
     let cache = FTCacheInfo(
       imageData: imageData,
       eTag: nil,
@@ -68,13 +70,12 @@ extension FTDiskCache {
       return hash.compactMap { String(format: "%02x", $0) }.joined()
   }
   
-  private func delete(fileName: String) {
-    try? fileManager.remove(fileName: fileName)
+  private func delete(fileName: String) async {
+    try? await fileManager.remove(fileName: fileName)
   }
   
-  private func isTimeOut(fileName: String) -> Bool {
-    if let attributes = try? fileManager.attributesOfItem(fileName: fileName),
-       let creationDate = attributes[.creationDate] as? Date {
+  private func isTimeOut(fileName: String) async -> Bool {
+    if let creationDate = try? await fileManager.getFileCreateDate(fileName: fileName) {
       if ttl < Date().timeIntervalSince(creationDate) {
         return true
       }

--- a/Sources/Feather/Model/FTDiskCacheConfig.swift
+++ b/Sources/Feather/Model/FTDiskCacheConfig.swift
@@ -7,10 +7,18 @@
 
 import Foundation
 
-public struct FTDiskCacheConfig: Sendable, Equatable {
-  public let timeOut: TimeInterval
+public struct FTDiskCacheConfig: Sendable {
+  let timeOut: TimeInterval
+  let policy: FTPolicy?
   
-  public init(timeOut: TimeInterval) {
+  public init(timeOut: TimeInterval = FTConstant.defaultTimeOut, policy: FTPolicyType = .none) {
     self.timeOut = timeOut
+    switch policy {
+    case .none:
+      self.policy = nil
+    case let .LRU(maxSize):
+      self.policy = LRUPolicy(maxSize: maxSize)
+    }
   }
 }
+

--- a/Sources/Feather/Network/FTDownloader.swift
+++ b/Sources/Feather/Network/FTDownloader.swift
@@ -20,7 +20,7 @@ final class FTDownloader: Sendable {
     var eTag: String?
     var modified: String?
     
-    if let (cache, isHit) = diskCache.read(requestURL: url) {
+    if let (cache, isHit) = await diskCache.read(requestURL: url) {
       if isHit {
         return cache.imageData
       } else {
@@ -41,16 +41,16 @@ final class FTDownloader: Sendable {
       guard let headers = response.allHeaderFields as? [String: Any] else { return data }
       let lowercasedHeaders = Dictionary(uniqueKeysWithValues: headers.map { ($0.lowercased(), $1) })
       if let eTag = lowercasedHeaders["etag"] as? String {
-        diskCache.save(requestURL: url, data: data, eTag: eTag, modified: nil)
+        await diskCache.save(requestURL: url, data: data, eTag: eTag, modified: nil)
         return data
       }  else if let lastModified = lowercasedHeaders["last-modified"] as? String {
-        diskCache.save(requestURL: url, data: data, eTag: nil, modified: lastModified)
+        await diskCache.save(requestURL: url, data: data, eTag: nil, modified: lastModified)
         return data
       }
-      diskCache.save(requestURL: url, data: data, eTag: nil, modified: nil)
+      await diskCache.save(requestURL: url, data: data, eTag: nil, modified: nil)
       return data
     case 304:
-      diskCache.save(requestURL: url, data: tempData, eTag: eTag, modified: modified)
+      await diskCache.save(requestURL: url, data: tempData, eTag: eTag, modified: modified)
       return tempData
     default: throw URLError(.badServerResponse)
     }

--- a/Sources/Feather/Policy/Interface/FTPolicy.swift
+++ b/Sources/Feather/Policy/Interface/FTPolicy.swift
@@ -5,7 +5,9 @@
 //  Created by 이시원 on 3/2/25.
 //
 
+import Foundation
+
 protocol FTPolicy: Sendable {
-  func execute(deleteHandler: (String) -> Void)
-  func updateAccessTime(fileName: String)
+  func execute() async -> [URL]
+  func updateAccessTime(fileName: String) async
 }

--- a/Sources/Feather/Policy/Interface/FTPolicy.swift
+++ b/Sources/Feather/Policy/Interface/FTPolicy.swift
@@ -1,0 +1,11 @@
+//
+//  FTPolicy.swift
+//  Feather
+//
+//  Created by 이시원 on 3/2/25.
+//
+
+protocol FTPolicy: Sendable {
+  func execute(deleteHandler: (String) -> Void)
+  func updateAccessTime(fileName: String)
+}


### PR DESCRIPTION
## 작업 내용
- LRU Cache Policy 구현
- FTFileManager Data Race 방지를 위한 class -> actor 변경

## Cache Policy 적용 방법
```swift
// LRU Policy
FTDiskCache.shared.config = FTDiskCacheConfig(policy: .LRU(maxSize: 1024 * 1024 * 1000))

// No Policy
FTDiskCache.shared.config = FTDiskCacheConfig(policy: .none)
```
- LRU 정책 적용 시 저장할 최대 용량을 함께 지정
- 최대 용량을 넘어갈 경우 LRU 정책에 따라 가장 오랫동안 접근하지 않은 Cache Data를 제거

## Caching 선능 개선

### 문제 상황
Policy가 동작할 때, 현재 캐싱된 총 데이터 크기가 설정된 maxSize를 초과했는지 확인하기 위해, 아래의 `calculateTotalSize()`를 호출해 현재 캐싱되어 있는 데이터의 총 크기를 구하고 있다.

```swift
  private func calculateTotalSize(_ files: [URL]) -> Int {
    return files.reduce(0) { totalSize, file in
      let fileSize = (try? fileManager.directorySize(at: file)) ?? 0
      return totalSize + fileSize
    }
  }
```

그러나, 캐싱된 이미지가 많아질수록 계산해야 하는 파일 수가 증가해, `calculateTotalSize()` 실행 시간이 점점 더 길어지는 문제가 발생했다. 즉, 캐싱된 파일 수가 n개라면, 이 메서드의 **시간 복잡도는 O(n)**이다.

실제로 성능을 측정해보면, 캐싱된 데이터가 **100개일 때는 약 16.8ms**가 소요되었지만, **1000개일 때는 약 121ms**가 소요되는 것으로 확인되었다.

### 해결 방법

총 캐싱 데이터 크기를 매번 계산하지 않고, 최초 한 번만 읽어온 뒤 아래처럼 `totalCacheSize` 변수에 저장해두는 방식으로 개선했다.

```swift
final class FTFileManager: @unchecked Sendable {
  private var totalCacheSize: Int?

  //.. 중략

  func getTotalCacheSize() -> Int {
    guard let totalCacheSize else {
      let totalSize = calculateTotalSize()
      totalCacheSize = totalSize
      return totalSize
    }
    return totalCacheSize
  }
```

이후 새로운 데이터가 저장되거나 삭제될 때마다, `totalCacheSize` 값을 함께 업데이트해 최신 상태를 유지한다.

다만, 데이터의 추가/삭제는 비동기적으로 발생할 수 있어, `totalCacheSize` 접근 시 **Data Race** 가능성이 존재한다.
이를 방지하기 위해, FTFileManager를 기존 **class에서 actor로 변경**해, 동시성 문제를 해결했다.

## 결과

동일하게 1000개의 데이터가 캐싱된 환경에서 **121ms -> 3.65ms로 약 97%의 성능 개선** 효과를 얻었다.